### PR TITLE
Optics integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 image: nkx1231/root6-geant4-garfield:0.8
 
-variables:
-      GIT_SUBMODULE_STRATEGY: recursive
+#variables:
+#      GIT_SUBMODULE_STRATEGY: recursive
 
 stages:
   - pre-build

--- a/inc/TRestAxionMCPLOptics.h
+++ b/inc/TRestAxionMCPLOptics.h
@@ -1,0 +1,53 @@
+/*************************************************************************
+ * This file is part of the REST software framework.                     *
+ *                                                                       *
+ * Copyright (C) 2016 GIFNA/TREX (University of Zaragoza)                *
+ * For more information see http://gifna.unizar.es/trex                  *
+ *                                                                       *
+ * REST is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * REST is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ * You should have a copy of the GNU General Public License along with   *
+ * REST in $REST_PATH/LICENSE.                                           *
+ * If not, see http://www.gnu.org/licenses/.                             *
+ * For the list of contributors see $REST_PATH/CREDITS.                  *
+ *************************************************************************/
+
+#ifndef _TRestAxionMCPLOptics
+#define _TRestAxionMCPLOptics
+
+#include <TRestAxionOptics.h>
+#include <iostream>
+
+/// A class to load optics response using MCPL files
+class TRestAxionMCPLOptics : public TRestAxionOptics {
+   private:
+    void Initialize();
+
+    /// The file containing the input particle list
+    std::string fInputMCPLFilename;
+
+    /// The file containing the output particle list
+    std::string fOutputMCPLFilename;
+
+   public:
+    void PrintMetadata();
+
+    void InitFromConfigFile();
+
+    TVector3 PropagatePhoton(const TVector3& in) { return TVector3(1, 1, 1); }
+
+    TRestAxionMCPLOptics();
+    TRestAxionMCPLOptics(const char* cfgFileName, std::string name = "");
+    ~TRestAxionMCPLOptics();
+
+    ClassDef(TRestAxionMCPLOptics, 1);
+};
+#endif

--- a/inc/TRestAxionOptics.h
+++ b/inc/TRestAxionOptics.h
@@ -29,11 +29,20 @@
 /// A class to load optics response files (WIP). Perhaps we might inherit later TRestAxionMCPLOptics, ...
 class TRestAxionOptics : public TRestMetadata {
    private:
-    /// It is the position of the optics system. Defined at the entrance of the optics
+    /// It is the position of the center of the optics system.
     TVector3 fCenter = TVector3(0, 0, 0);
 
     /// The axis of the optics system
-    TVector3 fAxis = TVector3(0, 0, 1);
+    TVector3 fAxis = TVector3(0, 0, 1);  //<
+
+    /// Optics length in mm
+    Double_t fLength = 50;  //<
+
+    /// It is the calculated position at the entrance of the optics.
+    TVector3 fEntrance;  //!
+
+    /// It is the calculated position at the exit of the optics.
+    TVector3 fExit;  //!
 
     void Initialize();
 
@@ -41,6 +50,8 @@ class TRestAxionOptics : public TRestMetadata {
     void PrintMetadata();
 
     void InitFromConfigFile();
+
+    virtual TVector3 PropagatePhoton(const TVector3& in);
 
     TRestAxionOptics();
     TRestAxionOptics(const char* cfgFileName, std::string name = "");

--- a/inc/TRestAxionOptics.h
+++ b/inc/TRestAxionOptics.h
@@ -30,13 +30,22 @@
 class TRestAxionOptics : public TRestMetadata {
    private:
     /// It is the position of the center of the optics system.
-    TVector3 fCenter = TVector3(0, 0, 0);
+    TVector3 fCenter = TVector3(0, 0, 0);  //<
 
     /// The axis of the optics system
     TVector3 fAxis = TVector3(0, 0, 1);  //<
 
-    /// Optics length in mm
-    Double_t fLength = 50;  //<
+    /// Optics physical mirror length in mm
+    Double_t fLength = 250;  //<
+
+    /// A vector containing the shells ring radius definitions. First element is the lower radius.
+    std::vector<std::pair<Double_t, Double_t>> fShellsRadii;  //<
+
+    /// An internal variable to register the maximum shell radius
+    Double_t fMaxShellRadius = -1;  //!
+
+    /// An internal variable to register the minimum shell radius
+    Double_t fMinShellRadius = -1;  //!
 
     /// It is the calculated position at the entrance of the optics.
     TVector3 fEntrance;  //!
@@ -46,12 +55,20 @@ class TRestAxionOptics : public TRestMetadata {
 
     void Initialize();
 
+    void SetMaxAndMinShellRadius();
+    Bool_t IsInsideRing(const TVector3& pos, Double_t Rout, Double_t Rin = 0);
+
    public:
+    TVector3 GetPositionAtEntrance(const TVector3& pos, const TVector3& dir);
+    TVector3 GetPositionAtExit(const TVector3& pos, const TVector3& dir);
+
+    Int_t GetEntranceShell(const TVector3& pos, const TVector3& dir);
+
     void PrintMetadata();
 
     void InitFromConfigFile();
 
-    virtual TVector3 PropagatePhoton(const TVector3& in);
+    virtual TVector3 PropagatePhoton(const TVector3& in) { return TVector3(0, 0, 0); }
 
     TRestAxionOptics();
     TRestAxionOptics(const char* cfgFileName, std::string name = "");

--- a/inc/TRestAxionOptics.h
+++ b/inc/TRestAxionOptics.h
@@ -53,12 +53,12 @@ class TRestAxionOptics : public TRestMetadata {
     /// It is the calculated position at the exit of the optics.
     TVector3 fExit;  //!
 
-    void Initialize();
-
     void SetMaxAndMinShellRadius();
     Bool_t IsInsideRing(const TVector3& pos, Double_t Rout, Double_t Rin = 0);
 
    public:
+    void Initialize();
+
     TVector3 GetPositionAtEntrance(const TVector3& pos, const TVector3& dir);
     TVector3 GetPositionAtExit(const TVector3& pos, const TVector3& dir);
 
@@ -68,7 +68,8 @@ class TRestAxionOptics : public TRestMetadata {
 
     void InitFromConfigFile();
 
-    virtual TVector3 PropagatePhoton(const TVector3& in) { return TVector3(0, 0, 0); }
+    /// Photon propagation method to be implemented at the derived class
+    virtual TVector3 PropagatePhoton(const TVector3& in) = 0;
 
     TRestAxionOptics();
     TRestAxionOptics(const char* cfgFileName, std::string name = "");

--- a/inc/TRestAxionOptics.h
+++ b/inc/TRestAxionOptics.h
@@ -59,6 +59,24 @@ class TRestAxionOptics : public TRestMetadata {
    public:
     void Initialize();
 
+    /// It returns the center of the optics system
+    TVector3 GetCenter() { return fCenter; }
+
+    /// It returns the axis vector of the optics system
+    TVector3 GetAxis() { return fAxis; }
+
+    /// It returns the physical length of the optics system
+    Double_t GetLength() { return fLength; }
+
+    /// It returns the number of shells implemented in the optics system
+    Int_t GetNumberOfShells() { return fShellsRadii.size(); }
+
+    /// It returns the entrance position defined by the optical axis
+    TVector3 GetEntrance() { return fEntrance; }
+
+    /// It returns the exit position defined by the optical axis
+    TVector3 GetExit() { return fExit; }
+
     TVector3 GetPositionAtEntrance(const TVector3& pos, const TVector3& dir);
     TVector3 GetPositionAtExit(const TVector3& pos, const TVector3& dir);
 

--- a/pipeline/optics/optics.py
+++ b/pipeline/optics/optics.py
@@ -9,7 +9,7 @@ mcplOptics_1 = ROOT.TRestAxionMCPLOptics("setups.rml", "mcpl")
 mcplOptics_1.PrintMetadata()
 
 shells = mcplOptics_1.GetNumberOfShells()
-print( "Number of shells: " + str(shells), end = "" )
+print( "Number of shells: " + str(shells) )
 if( shells != 5 ):
     print( "\nError! Number of shells is not 5!" )
     exit(1)

--- a/pipeline/optics/optics.py
+++ b/pipeline/optics/optics.py
@@ -5,18 +5,23 @@ import ROOT
 ROOT.gSystem.Load("libRestFramework.so")
 ROOT.gSystem.Load("libRestAxion.so")
 
-mcplOptics_1 = ROOT.TRestAxionMagneticField("setups.rml", "mcpl")
+mcplOptics_1 = ROOT.TRestAxionMCPLOptics("setups.rml", "mcpl")
 mcplOptics_1.PrintMetadata()
 
-mcplOptics_2 = ROOT.TRestAxionMagneticField("setups.rml", "mcpl2")
-mcplOptics_2.PrintMetadata()
+shells = mcplOptics_1.GetNumberOfShells()
+print( "Number of shells: " + str(shells), end = "" )
+if( shells != 5 ):
+    print( "\nError! Number of shells is not 5!" )
+    exit(1)
+print (" [\033[92m OK \x1b[0m]")
 
-mcplOptics_3 = ROOT.TRestAxionMagneticField("setups.rml", "mcpl3")
-mcplOptics_3.PrintMetadata()
+#mcplOptics_2 = ROOT.TRestAxionMagneticField("setups.rml", "mcpl2")
+#mcplOptics_2.PrintMetadata()
+
+#mcplOptics_3 = ROOT.TRestAxionMagneticField("setups.rml", "mcpl3")
+#mcplOptics_3.PrintMetadata()
 
 
-print ( "Setups where loaded properly" )
-print ("[\033[92m OK \x1b[0m]")
 
 print ("All tests passed!")
 

--- a/pipeline/optics/setups.rml
+++ b/pipeline/optics/setups.rml
@@ -1,5 +1,5 @@
 <xml>
-<TRestAxionOptics name="mcpl" >
+<TRestAxionMCPLOptics name="mcpl" >
 	<parameter name="center" value="(0,0,200)mm" />
 	<parameter name="axis" value="(0,0.02,0.98)" />
 	<parameter name="length" value="22cm" />
@@ -8,7 +8,10 @@
 	<parameter name="shellMinRadii" value="5,10,15,20,25" />
 	<parameter name="shellMaxRadii" value="9.9,14.9,19.9,24.9,29.9" />
 
-</TRestAxionOptics>
+	<parameter name="inputMCPLFilename" value="dummyInput.mcpl" />
+	<parameter name="outputMCPLFilename" value="dummyOutput.mcpl" />
+
+</TRestAxionMCPLOptics>
 
 <TRestAxionOptics name="mcpl2" center="(0,0,300)cm" axis="(0,0,3)" />
 

--- a/pipeline/optics/setups.rml
+++ b/pipeline/optics/setups.rml
@@ -1,7 +1,13 @@
 <xml>
 <TRestAxionOptics name="mcpl" >
 	<parameter name="center" value="(0,0,200)mm" />
-	<parameter name="axis" value="(0,0,1)" />
+	<parameter name="axis" value="(0,0.02,0.98)" />
+	<parameter name="length" value="22cm" />
+
+	<!-- We build mirror shells with 0.1mm thickness -->
+	<parameter name="shellMinRadii" value="5,10,15,20,25" />
+	<parameter name="shellMaxRadii" value="9.9,14.9,19.9,24.9,29.9" />
+
 </TRestAxionOptics>
 
 <TRestAxionOptics name="mcpl2" center="(0,0,300)cm" axis="(0,0,3)" />

--- a/src/TRestAxionMCPLOptics.cxx
+++ b/src/TRestAxionMCPLOptics.cxx
@@ -1,0 +1,142 @@
+/******************** REST disclaimer ***********************************
+ * This file is part of the REST software framework.                     *
+ *                                                                       *
+ * Copyright (C) 2016 GIFNA/TREX (University of Zaragoza)                *
+ * For more information see http://gifna.unizar.es/trex                  *
+ *                                                                       *
+ * REST is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * REST is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ * You should have a copy of the GNU General Public License along with   *
+ * REST in $REST_PATH/LICENSE.                                           *
+ * If not, see http://www.gnu.org/licenses/.                             *
+ * For the list of contributors see $REST_PATH/CREDITS.                  *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+/// TRestAxionMCPLOptics is a class that inherits from TRestAxionOptics.
+/// It will load the optics response from a MCPL file, and inherit the common
+/// optics description.
+///
+/// This method will implement the pure virtual method PropagatePhoton, that
+/// will be responsible to move a particle to the exit plane of the optics.
+/// It may use the common methods defined at TRestAxionOptics.
+///
+/// ### RML definition
+///
+/// We can add any number of magnetic volumes inside the RML definition
+/// as shown in the following piece of code,
+///
+/// Example 1:
+/// \code
+/// <TRestAxionMCPLOptics name="mcpl" >
+///	   <parameter name="center" value="(0,0,200)mm" />
+///	   <parameter name="axis" value="(0,0.02,0.98)" />
+///	   <parameter name="length" value="22cm" />
+///
+///	   <!-- We build mirror shells with 0.1mm thickness -->
+///	   <parameter name="shellMinRadii" value="5,10,15,20,25" />
+///	   <parameter name="shellMaxRadii" value="9.9,14.9,19.9,24.9,29.9" />
+/// </TRestAxionMCPLOptics>
+/// \endcode
+///
+///--------------------------------------------------------------------------
+///
+/// RESTsoft - Software for Rare Event Searches with TPCs
+///
+/// History of developments:
+///
+/// 2022-February: First concept and implementation of TRestAxionMCPLOptics class.
+///            	  Javier Galan
+///
+/// \class      TRestAxionMCPLOptics
+/// \author     Javier Galan <javier.galan@unizar.es>
+///
+/// <hr>
+///
+
+#include "TRestAxionMCPLOptics.h"
+
+using namespace std;
+
+#include "TRestPhysics.h"
+using namespace REST_Physics;
+
+ClassImp(TRestAxionMCPLOptics);
+
+///////////////////////////////////////////////
+/// \brief Default constructor
+///
+TRestAxionMCPLOptics::TRestAxionMCPLOptics() : TRestAxionOptics() { Initialize(); }
+
+///////////////////////////////////////////////
+/// \brief Constructor loading data from a config file
+///
+/// If no configuration path is defined using TRestMetadata::SetConfigFilePath
+/// the path to the config file must be specified using full path, absolute or
+/// relative.
+///
+/// The default behaviour is that the config file must be specified with
+/// full path, absolute or relative.
+///
+/// \param cfgFileName A const char* giving the path to an RML file.
+/// \param name The name of the specific metadata. It will be used to find the
+/// corresponding TRestAxionMagneticField section inside the RML.
+///
+TRestAxionMCPLOptics::TRestAxionMCPLOptics(const char* cfgFileName, string name)
+    : TRestAxionOptics(cfgFileName) {
+    debug << "Entering TRestAxionMCPLOptics constructor( cfgFileName, name )" << endl;
+
+    Initialize();
+
+    LoadConfigFromFile(fConfigFileName, name);
+
+    if (GetVerboseLevel() >= REST_Info) PrintMetadata();
+}
+
+///////////////////////////////////////////////
+/// \brief Default destructor
+///
+TRestAxionMCPLOptics::~TRestAxionMCPLOptics() {}
+
+///////////////////////////////////////////////
+/// \brief Initialization of TRestAxionMCPLOptics members
+///
+void TRestAxionMCPLOptics::Initialize() {
+    TRestAxionOptics::Initialize();
+
+    SetSectionName(this->ClassName());
+    SetLibraryVersion(LIBRARY_VERSION);
+}
+
+///////////////////////////////////////////////
+/// \brief Initialization of TRestAxionMCPLOptics field members through a RML file
+///
+void TRestAxionMCPLOptics::InitFromConfigFile() {
+    TRestAxionOptics::InitFromConfigFile();
+
+    fInputMCPLFilename = GetParameter("inputMCPLFilename", "none");
+    fOutputMCPLFilename = GetParameter("outputMCPLFilename", "none");
+
+    // If we recover the metadata class from ROOT file we will need to call Initialize ourselves
+    this->Initialize();
+}
+
+///////////////////////////////////////////////
+/// \brief Prints on screen the information about the metadata members of TRestAxionMCPLOptics
+///
+void TRestAxionMCPLOptics::PrintMetadata() {
+    TRestAxionOptics::PrintMetadata();
+
+    metadata << "---------" << endl;
+    metadata << "Input MCPL file: " << fInputMCPLFilename << endl;
+    metadata << "Output MCPL file: " << fOutputMCPLFilename << endl;
+    metadata << "+++++++++++++++++++++++++++++++++++++++++++++++++" << endl;
+}

--- a/src/TRestAxionOptics.cxx
+++ b/src/TRestAxionOptics.cxx
@@ -124,6 +124,9 @@ TRestAxionOptics::~TRestAxionOptics() {}
 void TRestAxionOptics::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
+
+    fEntrance = fCenter - 0.5 * fLength * fAxis;
+    fExit = fCenter + 0.5 * fLength * fAxis;
 }
 
 ///////////////////////////////////////////////
@@ -142,8 +145,11 @@ void TRestAxionOptics::InitFromConfigFile() {
 void TRestAxionOptics::PrintMetadata() {
     TRestMetadata::PrintMetadata();
 
+    metadata << "Optics entrance: (" << fEntrance.X() << ", " << fEntrance.Y() << ", " << fEntrance.Z() << ")"
+             << endl;
     metadata << "Optics center: (" << fCenter.X() << ", " << fCenter.Y() << ", " << fCenter.Z() << ")"
              << endl;
+    metadata << "Optics exit: (" << fExit.X() << ", " << fExit.Y() << ", " << fExit.Z() << ")" << endl;
     metadata << "Optics axis: (" << fAxis.X() << ", " << fAxis.Y() << ", " << fAxis.Z() << ")" << endl;
     metadata << "+++++++++++++++++++++++++++++++++++++++++++++++++" << endl;
 }

--- a/src/TRestAxionOptics.cxx
+++ b/src/TRestAxionOptics.cxx
@@ -127,16 +127,96 @@ void TRestAxionOptics::Initialize() {
 
     fEntrance = fCenter - 0.5 * fLength * fAxis;
     fExit = fCenter + 0.5 * fLength * fAxis;
+
+    SetMaxAndMinShellRadius();
+}
+
+///////////////////////////////////////////////
+/// \brief It initializes the fMaxShellRadius and fMinShellRadius using the shell ring definitions
+///
+void TRestAxionOptics::SetMaxAndMinShellRadius() {
+    if (fMinShellRadius == -1 && fShellsRadii.size() > 0) fMinShellRadius = fShellsRadii[0].first;
+    if (fMaxShellRadius == -1 && fShellsRadii.size() > 0) fMaxShellRadius = fShellsRadii[0].second;
+
+    for (const auto& shellRadius : fShellsRadii) {
+        if (shellRadius.first < fMinShellRadius) fMinShellRadius = shellRadius.first;
+        if (shellRadius.second > fMaxShellRadius) fMaxShellRadius = shellRadius.second;
+    }
+}
+
+///////////////////////////////////////////////
+/// \brief It moves a given particle with position `pos` and direction `dir` to the entrance of the optics
+///
+TVector3 TRestAxionOptics::GetPositionAtEntrance(const TVector3& pos, const TVector3& dir) {
+    return REST_Physics::MoveToPlane(pos, dir, fAxis, fEntrance);
+}
+
+///////////////////////////////////////////////
+/// \brief It moves a given particle with position `pos` and direction `dir` to the exit of the optics
+///
+TVector3 TRestAxionOptics::GetPositionAtExit(const TVector3& pos, const TVector3& dir) {
+    return REST_Physics::MoveToPlane(pos, dir, fAxis, fEntrance);
+}
+
+///////////////////////////////////////////////
+/// \brief It determines if a given particle with position `pos` (that **should be** already placed
+/// at the entrance plane of the optics) will be inside a ring with radius between `Rin` and `Rout`.
+///
+/// This method is private since it is just a helper method used by GetRing.
+///
+Bool_t TRestAxionOptics::IsInsideRing(const TVector3& pos, Double_t Rout, Double_t Rin) {
+    Double_t d = REST_Physics::DistanceToAxis(fEntrance, fAxis, pos);
+
+    if (d < Rout && d >= Rin) return true;
+
+    return false;
+}
+
+///////////////////////////////////////////////
+/// \brief It returns the optics shell index for a given particle with position `pos` and direction `dir`.
+///
+/// If the particle is not inside any ring it will return -1
+///
+/// This method is protected since it should be used only by derived classes
+///
+Int_t TRestAxionOptics::GetEntranceShell(const TVector3& pos, const TVector3& dir) {
+    TVector3 posEntrance = GetPositionAtEntrance(pos, dir);
+    if (!IsInsideRing(posEntrance, fMaxShellRadius, fMinShellRadius)) return -1;
+
+    int n = 0;
+    for (const auto& shellRadius : fShellsRadii) {
+        if (IsInsideRing(posEntrance, shellRadius.second, shellRadius.first)) return n;
+        n++;
+    }
+
+    return -1;
 }
 
 ///////////////////////////////////////////////
 /// \brief Initialization of TRestAxionOptics field members through a RML file
 ///
 void TRestAxionOptics::InitFromConfigFile() {
-    this->Initialize();
-
     fCenter = Get3DVectorParameterWithUnits("center", TVector3(0, 0, 0));
-    fAxis = Get3DVectorParameterWithUnits("axis", TVector3(0, 0, 2));
+    fAxis = Get3DVectorParameterWithUnits("axis", TVector3(0, 0, 2)).Unit();
+    fLength = GetDblParameterWithUnits("lenght", 250);
+
+    std::vector<Double_t> rMax = StringToElements(GetParameter("shellMaxRadii", "-1"), ",");
+    std::vector<Double_t> rMin = StringToElements(GetParameter("shellMinRadii", "-1"), ",");
+
+    if (rMax.size() != rMin.size())
+        SetError(
+            "TRestAxionOptics. The number of ring radii definitions do not match! Rings will not be "
+            "initialized!");
+    else {
+        fShellsRadii.clear();
+        for (unsigned int n = 0; n < rMax.size(); n++) {
+            std::pair<Double_t, Double_t> p(rMin[n], rMax[n]);
+            fShellsRadii.push_back(p);
+        }
+    }
+
+    // If we recover the metadata class from ROOT file we will need to call Initialize ourselves
+    this->Initialize();
 }
 
 ///////////////////////////////////////////////
@@ -145,11 +225,21 @@ void TRestAxionOptics::InitFromConfigFile() {
 void TRestAxionOptics::PrintMetadata() {
     TRestMetadata::PrintMetadata();
 
-    metadata << "Optics entrance: (" << fEntrance.X() << ", " << fEntrance.Y() << ", " << fEntrance.Z() << ")"
+    metadata << "Optics length: " << fLength << " mm" << endl;
+    metadata << "Optics entrance: (" << fEntrance.X() << ", " << fEntrance.Y() << ", " << fEntrance.Z()
+             << ") mm" << endl;
+    metadata << "Optics center: (" << fCenter.X() << ", " << fCenter.Y() << ", " << fCenter.Z() << ") mm"
              << endl;
-    metadata << "Optics center: (" << fCenter.X() << ", " << fCenter.Y() << ", " << fCenter.Z() << ")"
-             << endl;
-    metadata << "Optics exit: (" << fExit.X() << ", " << fExit.Y() << ", " << fExit.Z() << ")" << endl;
+    metadata << "Optics exit: (" << fExit.X() << ", " << fExit.Y() << ", " << fExit.Z() << ") mm" << endl;
     metadata << "Optics axis: (" << fAxis.X() << ", " << fAxis.Y() << ", " << fAxis.Z() << ")" << endl;
+    metadata << " " << endl;
+    metadata << "Relation of mirror shells integrated in the optics:" << endl;
+    metadata << "---------" << endl;
+    int n = 0;
+    for (const auto& shellRadius : fShellsRadii) {
+        metadata << "Shell " << n << ": Rmin = " << shellRadius.first << "mm , Rmax = " << shellRadius.second
+                 << "mm" << endl;
+        n++;
+    }
     metadata << "+++++++++++++++++++++++++++++++++++++++++++++++++" << endl;
 }


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![372](https://badgen.net/badge/Size/372/orange) [![](https://gitlab.cern.ch/rest-for-physics/axionlib/badges/optics/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/axionlib/-/commits/optics)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

= `TRestAxionOptics` implemented as a base class to support derived classes: `TRestAxionMCPLOptics` and `TRestAxionGenericOptics`.

- We define `fCenter`, `fLength` and `fAxis` to fix the optics size, position and orientation.
- Implemented shells radii description inside `fShellsRadii` metadata member.
- Integrated the retrieval of shell radii inside `InitFromConfigFile`.
- Implemented methods `GetPositionAtEntrance` to translate a particle position and direction to the optics entrance plane. `GetPositionAtExit` was also implemented but it is not clear to me if it will be needed.
- Implemented `GetEntranceShell` method to identify the shell where the particle is entering. It will return -1 if the particle is not entering any shell.

= Added `TRestAxionMCPLOptics`.
- It reads input/output filenames on top of other TRestAxionOptics data members.