### PR TITLE
TRestAxionMagneticField. Removing buffer gas dependency

### DIFF
--- a/inc/TRestAxionMagneticField.h
+++ b/inc/TRestAxionMagneticField.h
@@ -31,7 +31,6 @@
 #include "TVector3.h"
 #include "TVectorD.h"
 
-#include "TRestAxionBufferGas.h"
 #include "TRestMesh.h"
 
 /// A structure to define the properties and store the field data of a single magnetic volume inside
@@ -45,9 +44,6 @@ struct MagneticFieldVolume {
 
     /// The field data connected to the grid defined by the mesh
     std::vector<std::vector<std::vector<TVector3>>> field;
-
-    /// A pointer to the gas properties
-    TRestAxionBufferGas* bGas = NULL;
 };
 
 /// A class to load magnetic field maps and evaluate the field on those maps including interpolation.
@@ -67,12 +63,6 @@ class TRestAxionMagneticField : public TRestMetadata {
 
     /// The type of the mesh used (default is cylindrical)
     std::vector<TString> fMeshType;  //<
-
-    /// The gas mixture components that define the medium in each magnetic volume
-    std::vector<TString> fGasMixtures;  //<
-
-    /// The gas components densities corresponding to the gas mixture defined for each volume
-    std::vector<TString> fGasDensities;  //<
 
     /// A vector to store the maximum bounding box values
     std::vector<TVector3> fBoundMax;  //<


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![3](https://badgen.net/badge/Size/3/orange) [![](https://gitlab.cern.ch/rest-for-physics/axionlib/badges/jgalan_magnetic_field/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/axionlib/-/commits/jgalan_magnetic_field)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is a simple PR to remove the buffer gas properties from `TRestAxionMagneticField`. Just to simplify the use of `TRestAxionMagneticField` to magnetic fields.

I realised that it is better to simply keep track of the magnetic field intensity for each particle inside the ray tracer. This is valid for any axion independently of the axion mass. 

Therefore, it is better to register the magnetic field profile at the ray-tracer and later on apply the relations for axion-photon conversion probability.

This might not be true if the solar axion flux would depend on the axion mass. But right now it is not important for IAXO.