### PR TITLE
Fixing a problem on TRestAxionGeneratorProcess. 

### DIFF
--- a/src/TRestAxionGeneratorProcess.cxx
+++ b/src/TRestAxionGeneratorProcess.cxx
@@ -184,8 +184,8 @@ TRestEvent* TRestAxionGeneratorProcess::ProcessEvent(TRestEvent* evInput) {
         if (energy > fMaxEnergy) return nullptr;
         Double_t radius = p.second;
 
-        axionPosition = TVector3(REST_Physics::solarRadius * radius * x,
-                                 REST_Physics::solarRadius * radius * y, -REST_Physics::AU);
+        axionPosition = TVector3(REST_Physics::solarRadius * radius * x / r,
+                                 REST_Physics::solarRadius * radius * y / r, -REST_Physics::AU);
 
         axionDirection = -axionPosition.Unit();
     }


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://gitlab.cern.ch/rest-for-physics/axionlib/badges/jgalan_flux_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/axionlib/-/commits/jgalan_flux_fix) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_flux_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_flux_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixing random solar generation to be at the corresponding random ring obtained by `TRestAxionSolarFlux`. `x` and `y` were not properly normalized.