### PR TITLE
TRestAxionXrayWindow. Adding vacuum material

### DIFF
--- a/src/TRestAxionXrayWindow.cxx
+++ b/src/TRestAxionXrayWindow.cxx
@@ -203,6 +203,10 @@ Double_t TRestAxionXrayWindow::GetTransmission(Double_t energy, Double_t x, Doub
 
     if (fMask && xNew * xNew + yNew * yNew > fMask->GetMaskRadius() * fMask->GetMaskRadius()) return 0;
 
+    /// No sense to define a pattern when using vacuum material
+    if (fMaterial == "vacuum") return 1;
+
+    /// If we do not hit the pattern the photon simply goes through.
     if (fMask && !fMask->HitsPattern(xNew, yNew)) return 1.;
 
     Double_t energyIndex = GetEnergyIndex(energy);


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 4](https://badgen.net/badge/PR%20Size/Ok%3A%204/green) [![](https://gitlab.cern.ch/rest-for-physics/axionlib/badges/jgalan_transmission/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/axionlib/-/commits/jgalan_transmission) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_transmission/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_transmission) [![](https://github.com/rest-for-physics/axionlib/actions/workflows/validation.yml/badge.svg?branch=jgalan_transmission)](https://github.com/rest-for-physics/axionlib/commits/jgalan_transmission)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

During the last IAXO CM we were discussing about the possibility to implement masks at given positions inside the ray-tracing.

For example, in order to constrain the ray-tracing only to the events that pass through end of the magnetic field definition.

I believe the process already exists and it is `TRestAxionTransmissionProcess`. Of course, this process requires that we define an X-ray window with a particular material. So, simply one could add `vacuum` as material (done at this PR).

After PR rest-for-physics/framework#304 we can also define a pattern mask without a pattern, used just to define the limits of the mask.

We could then define the MagnetBore exit as follows:

```
<TRestAxionXrayWindow name="magnetBoreExit"  material="vacuum" >
            <TRestPatternMask name="magnetMask"  maxRadius="70cm" />
</TRestAxionXrayWindow>
```

We should then remind that the physical position of the mask will be chosen by `TRestAxionTransmissionProcess`, through `fCenter` defined by `TRestAxionEventProcess` mother class.