### PR TITLE
TRestAxionSolarFlux::GetFluxInRange method added

### DIFF
--- a/inc/TRestAxionSolarFlux.h
+++ b/inc/TRestAxionSolarFlux.h
@@ -56,7 +56,7 @@ class TRestAxionSolarFlux : public TRestMetadata {
     /// It will be used when loading `.flux` files to define the threshold for peak identification
     Double_t fPeakSigma = 0;  //<
 
-    /// The tabulated solar flux continuum spectra TH1F(100,0,20)keV in cm-2 s-1 keV-1 versus solar radius
+    /// The tabulated solar flux continuum spectra TH1F(200,0,20)keV in cm-2 s-1 keV-1 versus solar radius
     std::vector<TH1F*> fFluxTable;  //!
 
     /// The tabulated solar flux in cm-2 s-1 for a number of monochromatic energies versus solar radius
@@ -108,6 +108,9 @@ class TRestAxionSolarFlux : public TRestMetadata {
 
     /// It returns true if monochromatic flux spectra was loaded
     Bool_t isSolarSpectrumLoaded() { return fFluxLines.size() > 0; }
+
+    /// It returns the integrated flux at earth in cm-2 s-1 for the given energy range
+    Double_t GetFluxInRange(TVector2 eRange = TVector2(-1, -1));
 
     /// It returns the total integrated flux at earth in cm-2 s-1
     Double_t GetTotalFlux() { return fTotalContinuumFlux + fTotalMonochromaticFlux; }

--- a/src/TRestAxionSolarFlux.cxx
+++ b/src/TRestAxionSolarFlux.cxx
@@ -678,6 +678,26 @@ void TRestAxionSolarFlux::IntegrateSolarFluxes() {
     fFluxRatio = fTotalMonochromaticFlux / (fTotalContinuumFlux + fTotalMonochromaticFlux);
 }
 
+Double_t TRestAxionSolarFlux::GetFluxInRange(TVector2 eRange) {
+    if (eRange.X() == -1 && eRange.Y() == -1) {
+        if (GetTotalFlux() == 0) IntegrateSolarFluxes();
+        return GetTotalFlux();
+    }
+
+    Double_t flux = 0;
+    for (const auto& line : fFluxLines)
+        if (line.first > eRange.X() && line.first < eRange.Y()) flux += line.second->Integral();
+
+    fTotalContinuumFlux = 0.0;
+    for (int n = 0; n < fFluxTable.size(); n++) {
+        flux += fFluxTable[n]->Integral(fFluxTable[n]->FindFixBin(eRange.X()),
+                                        fFluxTable[n]->FindFixBin(eRange.Y())) *
+                0.1;  // We integrate in 100eV steps
+    }
+
+    return flux;
+}
+
 ///////////////////////////////////////////////
 /// \brief It returns a random solar radius position and energy according to the
 /// flux distributions defined inside the solar tables loaded in the class

--- a/src/TRestAxionSolarFlux.cxx
+++ b/src/TRestAxionSolarFlux.cxx
@@ -678,6 +678,9 @@ void TRestAxionSolarFlux::IntegrateSolarFluxes() {
     fFluxRatio = fTotalMonochromaticFlux / (fTotalContinuumFlux + fTotalMonochromaticFlux);
 }
 
+///////////////////////////////////////////////
+/// \brief It returns the integrated flux at earth in cm-2 s-1 for the given energy range
+///
 Double_t TRestAxionSolarFlux::GetFluxInRange(TVector2 eRange) {
     if (eRange.X() == -1 && eRange.Y() == -1) {
         if (GetTotalFlux() == 0) IntegrateSolarFluxes();


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 28](https://badgen.net/badge/PR%20Size/Ok%3A%2028/green) [![](https://gitlab.cern.ch/rest-for-physics/axionlib/badges/jgalan_solar_upgrade/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/axionlib/-/commits/jgalan_solar_upgrade) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_solar_upgrade/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_solar_upgrade) [![](https://github.com/rest-for-physics/axionlib/actions/workflows/validation.yml/badge.svg?branch=jgalan_solar_upgrade)](https://github.com/rest-for-physics/axionlib/commits/jgalan_solar_upgrade)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- A new method has been added to get the flux integrated in a specific energy range

It can be used to get solar flux from a root generated file, once it is open using `restRoot REST_file.root`.

<img width="798" alt="Screenshot 2022-11-18 at 12 13 50" src="https://user-images.githubusercontent.com/12447509/202692810-7f6e566b-b206-4533-ab19-778b06e40928.png">