### PR TITLE
Adding missing PrintMetadata info

### DIFF
--- a/src/TRestAxionEventProcess.cxx
+++ b/src/TRestAxionEventProcess.cxx
@@ -119,10 +119,20 @@ void TRestAxionEventProcess::EndOfEventProcess(TRestEvent* evInput) {
 void TRestAxionEventProcess::BeginPrintProcess() {
     TRestEventProcess::BeginPrintProcess();
 
-    RESTMetadata << "fPosition: (" << fPosition.X() << ", " << fPosition.Y() << ", " << fPosition.Z()
-                 << ") mm" << RESTendl;
-    RESTMetadata << "Yaw angle (Y-axis): " << fInternalYaw * units("degrees") << " degrees" << RESTendl;
-    RESTMetadata << "Pitch angle (X-axis): " << fInternalPitch * units("degrees") << " degrees" << RESTendl;
+    RESTMetadata << "Position: (" << fPosition.X() << ", " << fPosition.Y() << ", " << fPosition.Z() << ") mm"
+                 << RESTendl;
+    RESTMetadata << " " << RESTendl;
+    RESTMetadata << "Internal Yaw angle (Y-axis): " << fInternalYaw * units("degrees") << " degrees"
+                 << RESTendl;
+    RESTMetadata << "Internal Pitch angle (X-axis): " << fInternalPitch * units("degrees") << " degrees"
+                 << RESTendl;
+    RESTMetadata << " " << RESTendl;
+    RESTMetadata << "External rotation center: (" << fExternalRotationCenter.X() << ", "
+                 << fExternalRotationCenter.Y() << ", " << fExternalRotationCenter.Z() << ") mm" << RESTendl;
+    RESTMetadata << "External Yaw angle (Y-axis): " << fExternalYaw * units("degrees") << " degrees"
+                 << RESTendl;
+    RESTMetadata << "External Pitch angle (X-axis): " << fExternalPitch * units("degrees") << " degrees"
+                 << RESTendl;
     RESTMetadata << " --------------------------- " << RESTendl;
     RESTMetadata << " " << RESTendl;
 }


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 14](https://badgen.net/badge/PR%20Size/Ok%3A%2014/green) [![](https://gitlab.cern.ch/rest-for-physics/axionlib/badges/jgalan_process_print/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/axionlib/-/commits/jgalan_process_print) [![](https://github.com/rest-for-physics/axionlib/actions/workflows/validation.yml/badge.svg?branch=jgalan_process_print)](https://github.com/rest-for-physics/axionlib/commits/jgalan_process_print)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

TRestAxionEventProcess::PrintMetadata updated to print external rotat…ion values