### PR TITLE
Adding REST_Axion_RayTracingNgamma.C macro

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -255,6 +255,8 @@ jobs:
         wget https://rest-for-physics.github.io/axionlib-data/transmission/C10H8O4.sol
         wget https://rest-for-physics.github.io/axionlib-data/optics/xmmTrueWolter.rml
         wget https://rest-for-physics.github.io/axionlib-data/optics/XMM.trueWolter
+        wget https://rest-for-physics.github.io/axionlib-data/opticsMirror/Reflectivity_Single_Au_250_Ni_0.4.N901f
+        wget https://rest-for-physics.github.io/axionlib-data/opticsMirror/Transmission_Single_Au_250_Ni_0.4.N901f
         wget https://rest-for-physics.github.io/axionlib-data/magneticField/fields.rml
         wget https://rest-for-physics.github.io/axionlib-data/magneticField/Bykovskiy_201906.dat
         wget https://rest-for-physics.github.io/axionlib-data/bufferGas/He.abs

--- a/macros/REST_Axion_RayTracingNgamma.C
+++ b/macros/REST_Axion_RayTracingNgamma.C
@@ -20,10 +20,11 @@ const std::string BabyIAXOFlux = "SolarFlux*GeneratorArea*(1000*MassInterval)/Ns
 //*** columns.
 //***
 //*** --------------
-//*** Usage: restManager RayTracingNGamma dataset.root [weight1,weight2] [normalizationFactor]
+//*** Usage: restManager RayTracingNGamma dataset.root [outputPath] [weight1,weight2] [normalizationFactor]
 //***
 //*******************************************************************************************************
-Int_t REST_Axion_RayTracingNGamma(const std::string& fname, const std::string& weights = BabyIAXOWeights,
+Int_t REST_Axion_RayTracingNGamma(const std::string& fname, const std::string& outputPath = "",
+                                  const std::string& weights = BabyIAXOWeights,
                                   const std::string& mcFlux = BabyIAXOFlux) {
     std::vector<std::string> ws = REST_StringHelper::Split(weights, ",");
 
@@ -54,7 +55,9 @@ Int_t REST_Axion_RayTracingNGamma(const std::string& fname, const std::string& w
 
     std::cout << "Writting to file: "
               << "DataSet_RayTracing_Ngamma_" << tag << ".root" << std::endl;
-    d.Export("DataSet_RayTracing_Ngamma_" + tag + ".root");
+    if (!outputPath.empty()) std::cout << "Output path: " << outputPath << std::endl;
+
+    d.Export(outputPath + "DataSet_RayTracing_Ngamma_" + tag + ".root");
 
     return 0;
 }

--- a/macros/REST_Axion_RayTracingNgamma.C
+++ b/macros/REST_Axion_RayTracingNgamma.C
@@ -1,0 +1,61 @@
+#include "TRestDataSet.h"
+#include "TRestTask.h"
+
+#ifndef RestTask_RayTracingNgamma
+#define RestTask_RayTracingNgamma
+
+const std::string BabyIAXOWeights =
+    "axionPhoton_probability,axionPhoton_transmission,boreExitGate_transmission,optics_efficiency,window_"
+    "transmission";
+const std::string BabyIAXOFlux = "SolarFlux*GeneratorArea*(1000*MassInterval)/Nsim";
+
+//*******************************************************************************************************
+//*** Description: This macro will add three new columns (Probability/Flux/Ngamma) to the dataset given
+//*** in the argument. The probability will be the result of the products of the weights given by argument,
+//*** the Flux will be a normalizing factor related to the solar flux and the number of simulated MC events,
+//*** and Ngamma will be the result of multiplying the Flux by Probability.
+//***
+//*** The weights must be existing columns in the given dataset
+//*** The normalization factor is a formula that may contain relevant quantites and existint dataset
+//*** columns.
+//***
+//*** --------------
+//*** Usage: restManager RayTracingNGamma dataset.root [weight1,weight2] [normalizationFactor]
+//***
+//*******************************************************************************************************
+Int_t REST_Axion_RayTracingNGamma(const std::string& fname, const std::string& weights = BabyIAXOWeights,
+                                  const std::string& mcFlux = BabyIAXOFlux) {
+    std::vector<std::string> ws = REST_StringHelper::Split(weights, ",");
+
+    TRestDataSet d;
+    d.Import(fname);
+
+    std::string probability = "";
+    int cont = 0;
+    for (const auto& w : ws) {
+        if (cont > 0) probability += "*";
+        probability += w;
+        cont++;
+    }
+    // std::cout << "Probability: " << probability << std::endl;
+
+    d.Define("Probability", probability);
+    d.Define("Flux", mcFlux);                // Per axion mass and second
+    d.Define("Ngamma", "Probability*Flux");  // (units: eV x s-1) Must be normalized by (and integrated to) a
+                                             // given axion mass interval
+                                             // --> TRestComponent
+
+    d.GetDataFrame().Display({"Probability", "Flux", "Ngamma"})->Print();
+
+    std::string tag = fname;
+    size_t pos1 = tag.find("_");
+    size_t pos2 = tag.find_last_of(".");
+    tag = tag.substr(pos1 + 1, pos2 - pos1 - 1);
+
+    std::cout << "Writting to file: "
+              << "DataSet_RayTracing_Ngamma_" << tag << ".root" << std::endl;
+    d.Export("DataSet_RayTracing_Ngamma_" + tag + ".root");
+
+    return 0;
+}
+#endif


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 64](https://badgen.net/badge/PR%20Size/Ok%3A%2064/green) [![](https://gitlab.cern.ch/rest-for-physics/axionlib/badges/jgalan_ngamma_macro/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/axionlib/-/commits/jgalan_ngamma_macro) [![](https://github.com/rest-for-physics/axionlib/actions/workflows/validation.yml/badge.svg?branch=jgalan_ngamma_macro)](https://github.com/rest-for-physics/axionlib/commits/jgalan_ngamma_macro)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adding a macro that extends the generated AnalysisTree dataset with new columns required for sensitivity analysis.

This macro could be in the framework since it makes use only of datasets. Although its scope is the calculation of probabilities and the normalisation of the simulation.

However, something similar will be required to normalise Geant4 MC simulations. @lobis

This PR requires the following PR to be merged: https://github.com/rest-for-physics/framework/pull/427