### PR TITLE
Fix External Rotation

### DIFF
--- a/src/TRestAxionEventProcess.cxx
+++ b/src/TRestAxionEventProcess.cxx
@@ -101,7 +101,7 @@ void TRestAxionEventProcess::EndOfEventProcess(TRestEvent* evInput) {
     fAxionEvent->Translate(TVector3(fPosition.X(), fPosition.Y(), fPosition.Z()));
     if (!fSkipEndProcessRotation) {
         fAxionEvent->RotateXY(fExternalRotationCenter, fExternalYaw, fExternalPitch);
-        fAxionEvent->RotateXY(fPosition, fInternalPitch, fInternalYaw);                             
+        fAxionEvent->RotateXY(fPosition, fInternalPitch, fInternalYaw);
     }
     RESTDebug << "EoEP: Final Position. X: " << fAxionEvent->GetPosition().X()
               << " Y: " << fAxionEvent->GetPosition().Y() << " Z: " << fAxionEvent->GetPosition().Z()

--- a/src/TRestAxionEventProcess.cxx
+++ b/src/TRestAxionEventProcess.cxx
@@ -99,8 +99,10 @@ void TRestAxionEventProcess::EndOfEventProcess(TRestEvent* evInput) {
               << RESTendl;
     RESTDebug << " ---- " << RESTendl;
     fAxionEvent->Translate(TVector3(fPosition.X(), fPosition.Y(), fPosition.Z()));
-    fAxionEvent->RotateYX(fExternalRotationCenter, fExternalYaw, fExternalPitch);
-    if (!fSkipEndProcessRotation) fAxionEvent->RotateXY(fPosition, fInternalPitch, fInternalYaw);
+    if (!fSkipEndProcessRotation) {
+        fAxionEvent->RotateXY(fExternalRotationCenter, fExternalYaw, fExternalPitch);
+        fAxionEvent->RotateXY(fPosition, fInternalPitch, fInternalYaw);                             
+    }
     RESTDebug << "EoEP: Final Position. X: " << fAxionEvent->GetPosition().X()
               << " Y: " << fAxionEvent->GetPosition().Y() << " Z: " << fAxionEvent->GetPosition().Z()
               << RESTendl;


### PR DESCRIPTION
![jovoy](https://badgen.net/badge/PR%20submitted%20by%3A/jovoy/blue) ![Ok: 4](https://badgen.net/badge/PR%20Size/Ok%3A%204/green) [![](https://gitlab.cern.ch/rest-for-physics/axionlib/badges/jovoy_acceptance/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/axionlib/-/commits/jovoy_acceptance) [![](https://github.com/rest-for-physics/axionlib/actions/workflows/validation.yml/badge.svg?branch=jovoy_acceptance)](https://github.com/rest-for-physics/axionlib/commits/jovoy_acceptance)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This will give the option to give the external rotation opticalAxis=true which will not rotate the rays back after rotation.