### PR TITLE
Introducing local axis

### DIFF
--- a/inc/TRestAxionEventProcess.h
+++ b/inc/TRestAxionEventProcess.h
@@ -64,7 +64,7 @@ class TRestAxionEventProcess : public TRestEventProcess {
     RESTValue GetOutputEvent() const override { return fAxionEvent; }
 
     virtual void InitProcess() override {}
-	
+
     /// It prints out the process parameters stored in the metadata structure
     virtual void PrintMetadata() override {
         BeginPrintProcess();

--- a/inc/TRestAxionEventProcess.h
+++ b/inc/TRestAxionEventProcess.h
@@ -30,25 +30,25 @@
 class TRestAxionEventProcess : public TRestEventProcess {
    private:
     /// The position of the component around which the rotation will be applied
-    TVector3 fPosition = TVector3(0, 0, 0);
+    TVector3 fPosition = TVector3(0, 0, 0); //<
 
     /// The rotation angle with respect to the Y-axis
-    Double_t fInternalYaw = 0;
+    Double_t fInternalYaw = 0; //<
 
     /// The rotation angle with respect to X-axis
-    Double_t fInternalPitch = 0;
+    Double_t fInternalPitch = 0; //<
 
     /// The position (different than the center of the object) around which the rotation will be applied
-    TVector3 fExternalRotationCenter = TVector3(0, 0, 0);
+    TVector3 fExternalRotationCenter = TVector3(0, 0, 0); //<
 
     /// The rotation angle around CenterSetup with respect to the Y-axis
-    Double_t fExternalYaw = 0;
+    Double_t fExternalYaw = 0; //<
 
     /// The rotation angle around CenterSetup with respect to X-axis
-    Double_t fExternalPitch = 0;
+    Double_t fExternalPitch = 0; //<
 
     /// If enabled it will skip the end rotation that recovers the original axion trajectory direction
-    Bool_t fSkipEndProcessRotation = false;  //!
+    Bool_t fLocalAxis = true;  //<
 
    protected:
     /// A pointer to the specific TRestAxionEvent
@@ -76,6 +76,6 @@ class TRestAxionEventProcess : public TRestEventProcess {
     TRestAxionEventProcess();
     ~TRestAxionEventProcess();
 
-    ClassDefOverride(TRestAxionEventProcess, 2);
+    ClassDefOverride(TRestAxionEventProcess, 3);
 };
 #endif

--- a/inc/TRestAxionEventProcess.h
+++ b/inc/TRestAxionEventProcess.h
@@ -64,6 +64,13 @@ class TRestAxionEventProcess : public TRestEventProcess {
     RESTValue GetOutputEvent() const override { return fAxionEvent; }
 
     virtual void InitProcess() override {}
+	
+    /// It prints out the process parameters stored in the metadata structure
+    virtual void PrintMetadata() override {
+        BeginPrintProcess();
+
+        EndPrintProcess();
+    }
 
     /// Begin of event process, preparation work. Called right before ProcessEvent()
     virtual void BeginOfEventProcess(TRestEvent* evInput = nullptr) override;

--- a/inc/TRestAxionEventProcess.h
+++ b/inc/TRestAxionEventProcess.h
@@ -59,8 +59,6 @@ class TRestAxionEventProcess : public TRestEventProcess {
 
     TVector3 GetCenter() const { return fPosition; }
 
-    void SkipEndProcessRotation(Bool_t value = true) { fSkipEndProcessRotation = value; }
-
    public:
     RESTValue GetInputEvent() const override { return fAxionEvent; }
     RESTValue GetOutputEvent() const override { return fAxionEvent; }

--- a/inc/TRestAxionOpticsProcess.h
+++ b/inc/TRestAxionOpticsProcess.h
@@ -45,18 +45,6 @@ class TRestAxionOpticsProcess : public TRestAxionEventProcess {
 
     void LoadConfig(std::string cfgFilename, std::string name = "");
 
-    /// It prints out the process parameters stored in the metadata structure
-    void PrintMetadata() override {
-        BeginPrintProcess();
-
-        if (fOpticalAxis)
-            RESTMetadata << "Output particle is described respect to the optical axis" << RESTendl;
-        else
-            RESTMetadata << "Output particle is described respect to the universal axis" << RESTendl;
-
-        EndPrintProcess();
-    }
-
     /// Returns the name of this process
     const char* GetProcessName() const override { return "axionOptics"; }
 

--- a/inc/TRestAxionOpticsProcess.h
+++ b/inc/TRestAxionOpticsProcess.h
@@ -30,9 +30,6 @@
 //! A process to introduce the response from optics in the axion signal generation chain
 class TRestAxionOpticsProcess : public TRestAxionEventProcess {
    private:
-    /// A variable to determine if the new axis will be optical or universal axis
-    Bool_t fOpticalAxis = false;  //<
-
     /// A pointer to the optics description defined inside TRestRun
     TRestAxionOptics* fOptics;  //!
 
@@ -43,17 +40,6 @@ class TRestAxionOpticsProcess : public TRestAxionEventProcess {
    protected:
    public:
     void InitProcess() override;
-
-    /// This InitFromConfigFile could be removed as soon as PR rest-for-physics/framework#275
-    /// is solved
-    void InitFromConfigFile() override {
-        TRestEventProcess::InitFromConfigFile();
-
-        if (ToUpper(GetParameter("opticalAxis", "false")) == "TRUE")
-            fOpticalAxis = true;
-        else
-            fOpticalAxis = false;
-    }
 
     TRestEvent* ProcessEvent(TRestEvent* evInput) override;
 

--- a/inc/TRestAxionOpticsProcess.h
+++ b/inc/TRestAxionOpticsProcess.h
@@ -55,6 +55,6 @@ class TRestAxionOpticsProcess : public TRestAxionEventProcess {
     // Destructor
     ~TRestAxionOpticsProcess();
 
-    ClassDefOverride(TRestAxionOpticsProcess, 1);
+    ClassDefOverride(TRestAxionOpticsProcess, 2);
 };
 #endif

--- a/src/TRestAxionEventProcess.cxx
+++ b/src/TRestAxionEventProcess.cxx
@@ -135,6 +135,7 @@ void TRestAxionEventProcess::BeginPrintProcess() {
                  << RESTendl;
     RESTMetadata << "External Pitch angle (X-axis): " << fExternalPitch * units("degrees") << " degrees"
                  << RESTendl;
+	RESTMetadata << " " << RESTendl;
     if (fLocalAxis)
         RESTMetadata << "Local axis is true " << RESTendl;
     else

--- a/src/TRestAxionEventProcess.cxx
+++ b/src/TRestAxionEventProcess.cxx
@@ -99,7 +99,7 @@ void TRestAxionEventProcess::EndOfEventProcess(TRestEvent* evInput) {
               << RESTendl;
     RESTDebug << " ---- " << RESTendl;
     fAxionEvent->Translate(TVector3(fPosition.X(), fPosition.Y(), fPosition.Z()));
-    if (!fSkipEndProcessRotation) {
+    if (!fLocalAxis) {
         fAxionEvent->RotateXY(fExternalRotationCenter, fExternalYaw, fExternalPitch);
         fAxionEvent->RotateXY(fPosition, fInternalPitch, fInternalYaw);
     }
@@ -135,6 +135,10 @@ void TRestAxionEventProcess::BeginPrintProcess() {
                  << RESTendl;
     RESTMetadata << "External Pitch angle (X-axis): " << fExternalPitch * units("degrees") << " degrees"
                  << RESTendl;
+	if( fLocalAxis ) 
+		RESTMetadata << "Local axis is true " << RESTendl;
+	else
+		RESTMetadata << "Universal axis is true " << RESTendl;
     RESTMetadata << " --------------------------- " << RESTendl;
     RESTMetadata << " " << RESTendl;
 }

--- a/src/TRestAxionEventProcess.cxx
+++ b/src/TRestAxionEventProcess.cxx
@@ -99,7 +99,7 @@ void TRestAxionEventProcess::EndOfEventProcess(TRestEvent* evInput) {
               << RESTendl;
     RESTDebug << " ---- " << RESTendl;
     fAxionEvent->Translate(TVector3(fPosition.X(), fPosition.Y(), fPosition.Z()));
-    if (!fLocalAxis) {
+    if (fLocalAxis) {
         fAxionEvent->RotateXY(fExternalRotationCenter, fExternalPitch, fExternalYaw);
         fAxionEvent->RotateXY(fPosition, fInternalPitch, fInternalYaw);
     }

--- a/src/TRestAxionEventProcess.cxx
+++ b/src/TRestAxionEventProcess.cxx
@@ -135,7 +135,7 @@ void TRestAxionEventProcess::BeginPrintProcess() {
                  << RESTendl;
     RESTMetadata << "External Pitch angle (X-axis): " << fExternalPitch * units("degrees") << " degrees"
                  << RESTendl;
-	RESTMetadata << " " << RESTendl;
+    RESTMetadata << " " << RESTendl;
     if (fLocalAxis)
         RESTMetadata << "Local axis is true " << RESTendl;
     else

--- a/src/TRestAxionEventProcess.cxx
+++ b/src/TRestAxionEventProcess.cxx
@@ -100,7 +100,7 @@ void TRestAxionEventProcess::EndOfEventProcess(TRestEvent* evInput) {
     RESTDebug << " ---- " << RESTendl;
     fAxionEvent->Translate(TVector3(fPosition.X(), fPosition.Y(), fPosition.Z()));
     if (!fLocalAxis) {
-        fAxionEvent->RotateXY(fExternalRotationCenter, fExternalYaw, fExternalPitch);
+        fAxionEvent->RotateXY(fExternalRotationCenter, fExternalPitch, fExternalYaw);
         fAxionEvent->RotateXY(fPosition, fInternalPitch, fInternalYaw);
     }
     RESTDebug << "EoEP: Final Position. X: " << fAxionEvent->GetPosition().X()

--- a/src/TRestAxionOpticsProcess.cxx
+++ b/src/TRestAxionOpticsProcess.cxx
@@ -115,17 +115,6 @@ void TRestAxionOpticsProcess::InitProcess() {
     } else {
         RESTError << "TRestAxionOptics::InitProcess. No sucess instantiating optics." << RESTendl;
     }
-
-    if (fOpticalAxis) {
-        // The outgoing particle will be referenced to the optical axis.
-        // The particle will not be counter-rotated when the process ends
-        SkipEndProcessRotation();
-    } else {
-        // The outgoing particle will be referenced to the universal axis
-        // The optics will apply a deflection angle, but the main axis will be kept aligned with the previous
-        // axis reference
-        SkipEndProcessRotation(false);
-    }
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 23](https://badgen.net/badge/PR%20Size/Ok%3A%2023/green) [![](https://gitlab.cern.ch/rest-for-physics/axionlib/badges/jgalan-axis/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/axionlib/-/commits/jgalan-axis) [![](https://github.com/rest-for-physics/axionlib/actions/workflows/validation.yml/badge.svg?branch=jgalan-axis)](https://github.com/rest-for-physics/axionlib/commits/jgalan-axis)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Now the local or universal axis is implemented at the level of `TRestAxionEventProcess` so that any component is capable to decide if the outgoing particle will be referred to the local component axis - defined by `TRestAxionEventProcess` yaw and pitch angles - or the universal axis - defined by the original reference system of the incoming particle,