### PR TITLE
TRestAxionFieldPropagationProcess. Added SetWarning

### DIFF
--- a/src/TRestAxionFieldPropagationProcess.cxx
+++ b/src/TRestAxionFieldPropagationProcess.cxx
@@ -197,6 +197,11 @@ TRestEvent* TRestAxionFieldPropagationProcess::ProcessEvent(TRestEvent* evInput)
     Double_t transmission = 1;
     Double_t fieldAverage = 0;
     if (trackBounds.size() == 2) {
+        RESTDebug << "-- Track bounds" << RESTendl;
+        RESTDebug << "X1:" << trackBounds[0].X() << " Y1: " << trackBounds[0].Y()
+                  << " Z1: " << trackBounds[0].Z() << RESTendl;
+        RESTDebug << "X2:" << trackBounds[1].X() << " Y2: " << trackBounds[1].Y()
+                  << " Z2: " << trackBounds[1].Z() << RESTendl;
         std::vector<Double_t> bProfile = fMagneticField->GetTransversalComponentAlongPath(
             trackBounds[0], trackBounds[1], fIntegrationStep);
 
@@ -214,7 +219,15 @@ TRestEvent* TRestAxionFieldPropagationProcess::ProcessEvent(TRestEvent* evInput)
             Double_t GammaL = Gamma * lCoh * units("cm");
             transmission = exp(-GammaL);
         }
+    } else {
+        SetWarning("TRestAxionFieldPropagationProcess. Track does not cross the field volume!", false);
     }
+
+    RESTDebug << " --- Process observables: " << RESTendl;
+    RESTDebug << "Field average: " << fieldAverage << " T" << RESTendl;
+    RESTDebug << "Probability: " << prob << " T" << RESTendl;
+    RESTDebug << "Coherence length: " << lCoh << " mm" << RESTendl;
+    RESTDebug << "Transmission: " << transmission << " mm" << RESTendl;
 
     SetObservableValue("fieldAverage", fieldAverage);
     SetObservableValue("probability", prob);


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 13](https://badgen.net/badge/PR%20Size/Ok%3A%2013/green) [![](https://github.com/rest-for-physics/axionlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=jgalan_add_warning)](https://github.com/rest-for-physics/axionlib/commits/jgalan_add_warning)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now, if the particles do not cross the magnetic volume, a warning will be generated in the process metadata warning messages.

<img width="1276" alt="Screenshot 2023-07-03 at 18 49 30" src="https://github.com/rest-for-physics/axionlib/assets/12447509/3b4d257a-682b-4212-a6dc-6720b300cd35">


To get the same output the following PR needs to be merged rest-for-physics/framework#456


