### PR TITLE
Change the documentation of TRestAxionBufferGas

### DIFF
--- a/src/TRestAxionBufferGas.cxx
+++ b/src/TRestAxionBufferGas.cxx
@@ -38,7 +38,7 @@
 /// \code
 /// TRestAxionBufferGas *gas = new TRestAxionBufferGas();
 ///
-/// //Density units must be expressed here in g/cm3
+/// //Density units must be expressed here in kg/mm3
 /// gas->SetGasDensity( "He", 2.6e-9 );
 /// gas->SetGasDensity( "Xe", 5.6e-9 );
 /// \endcode

--- a/src/TRestAxionBufferGas.cxx
+++ b/src/TRestAxionBufferGas.cxx
@@ -57,7 +57,7 @@
 /// \code
 ///	<TRestAxionBufferGas name="heliumAndXenon" verboseLevel="warning" >
 ///		<gas name="He" density="2.6e-9"/>
-///		<gas name="Xe" density="5.6mg/cm3"/>
+///		<gas name="Xe" density="5.6mg/cm^3"/>
 ///	</TRestAxionBufferGas>
 /// \endcode
 ///

--- a/src/TRestAxionBufferGas.cxx
+++ b/src/TRestAxionBufferGas.cxx
@@ -48,7 +48,7 @@
 /// \code
 /// TRestAxionBufferGas *gas = new TRestAxionBufferGas();
 ///
-/// gas->SetGasMixture( "He+Xe", "2.6e-6g/dm3+5.6mg/m3" );
+/// gas->SetGasMixture( "He+Xe", "2.6e-6g/dm^3+5.6mg/m^3" );
 /// \endcode
 ///
 /// The corresponding RML section for initialization through a configuration


### PR DESCRIPTION
![francandon](https://badgen.net/badge/PR%20submitted%20by%3A/francandon/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://github.com/rest-for-physics/axionlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=fran_DOC)](https://github.com/rest-for-physics/axionlib/commits/fran_DOC) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

1) Change where appears that units of density in SetGasDensity must be written in g/cm3 when in fact must be kg/m3
2) Missing ^ in the line gas->[SetGasMixture](https://sultan.unizar.es/rest/classTRestAxionBufferGas.html#a42d37330437aa259a8faf43a9f8c4b1d)( "He+Xe", "2.6e-6g/dm3+5.6mg/m3" );


There is only one file changed:
- TRestAxionBufferGas.cxx