### PR TITLE
Change Axion generator Target Position

### DIFF
--- a/inc/TRestAxionAnalysisProcess.h
+++ b/inc/TRestAxionAnalysisProcess.h
@@ -32,6 +32,9 @@ class TRestAxionAnalysisProcess : public TRestEventProcess {
     /// A pointer to the specific TRestAxionEvent
     TRestAxionEvent* fAxionEvent;  //!
 
+    /// The analysis position in mm with regards to the sun at (0,0,-AU).
+    TVector3 fAnalysisPosition = TVector3(0, 0, 0);  //<
+
     void Initialize() override;
 
     void LoadDefaultConfig();

--- a/inc/TRestAxionGeneratorProcess.h
+++ b/inc/TRestAxionGeneratorProcess.h
@@ -50,7 +50,7 @@ class TRestAxionGeneratorProcess : public TRestEventProcess {
     Double_t fTargetRadius = 800;  //<
 
     /// The target position in mm with regards to the sun at (0,0,-AU).
-    TVector3 fTargetPosition = TVector3(0 ,0 ,0 );  //<
+    TVector3 fTargetPosition = TVector3(0, 0, 0);  //<
 
     /// The generator type (solarFlux/flat)
     TString fGeneratorType = "solarFlux";  //<

--- a/inc/TRestAxionGeneratorProcess.h
+++ b/inc/TRestAxionGeneratorProcess.h
@@ -49,6 +49,9 @@ class TRestAxionGeneratorProcess : public TRestEventProcess {
     /// The target size in mm (or generator source extension) for the generator.
     Double_t fTargetRadius = 800;  //<
 
+    /// The target position in mm with regards to the sun at (0,0,-AU).
+    TVector3 fTargetPosition = TVector3(0 ,0 ,0 );  //<
+
     /// The generator type (solarFlux/flat)
     TString fGeneratorType = "solarFlux";  //<
 

--- a/src/TRestAxionAnalysisProcess.cxx
+++ b/src/TRestAxionAnalysisProcess.cxx
@@ -125,13 +125,14 @@ TRestEvent* TRestAxionAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
 
     SetObservableValue("energy", fAxionEvent->GetEnergy());
     SetObservableValue("mass", fAxionEvent->GetMass() * units("eV"));
-
-    Double_t x = fAxionEvent->GetPosition().X();
-    Double_t y = fAxionEvent->GetPosition().Y();
+    
+    Double_t x = fAxionEvent->GetPosition().X() - fAnalysisPosition.X();
+    Double_t y = fAxionEvent->GetPosition().Y() - fAnalysisPosition.Y();
     SetObservableValue("posX", x);
     SetObservableValue("posY", y);
     SetObservableValue("posZ", fAxionEvent->GetPosition().Z());
 
+    /// The following only works if the center of the signal is where the analysis position is.
     Double_t r = TMath::Sqrt(x * x + y * y);
     SetObservableValue("R", r);
 

--- a/src/TRestAxionAnalysisProcess.cxx
+++ b/src/TRestAxionAnalysisProcess.cxx
@@ -125,7 +125,7 @@ TRestEvent* TRestAxionAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
 
     SetObservableValue("energy", fAxionEvent->GetEnergy());
     SetObservableValue("mass", fAxionEvent->GetMass() * units("eV"));
-    
+
     Double_t x = fAxionEvent->GetPosition().X() - fAnalysisPosition.X();
     Double_t y = fAxionEvent->GetPosition().Y() - fAnalysisPosition.Y();
     SetObservableValue("posX", x);

--- a/src/TRestAxionGeneratorProcess.cxx
+++ b/src/TRestAxionGeneratorProcess.cxx
@@ -166,7 +166,7 @@ TRestEvent* TRestAxionGeneratorProcess::ProcessEvent(TRestEvent* evInput) {
 
     /// The axion position must be displaced by the target size.
     /// We always do this. It is independent of generator
-    /// The target is virtually placed at the (0,0,0) + TargetPosition since the 
+    /// The target is virtually placed at the (0,0,0) + TargetPosition since the
     /// experiment is not focussed by the bore but by the whole experiment.
     /// In my opinion the target should be either the optics, or the magnet end bore.
     /// Then one should place the optics or the magnet end bore at the (0,0,0) + TargetPosition.

--- a/src/TRestAxionGeneratorProcess.cxx
+++ b/src/TRestAxionGeneratorProcess.cxx
@@ -170,6 +170,8 @@ TRestEvent* TRestAxionGeneratorProcess::ProcessEvent(TRestEvent* evInput) {
     /// experiment is not focussed by the bore but by the whole experiment.
     /// In my opinion the target should be either the optics, or the magnet end bore.
     /// Then one should place the optics or the magnet end bore at the (0,0,0) + TargetPosition.
+    /// TODO: The target position and the magnetic field have to be in the same spot in x- and y-direction
+    /// apparently.
     ///
     do {
         x = 2 * (fRandom->Rndm() - 0.5);

--- a/src/TRestAxionGeneratorProcess.cxx
+++ b/src/TRestAxionGeneratorProcess.cxx
@@ -166,9 +166,10 @@ TRestEvent* TRestAxionGeneratorProcess::ProcessEvent(TRestEvent* evInput) {
 
     /// The axion position must be displaced by the target size.
     /// We always do this. It is independent of generator
-    /// The target is virtually placed at the (0,0,0).
+    /// The target is virtually placed at the (0,0,0) + TargetPosition since the 
+    /// experiment is not focussed by the bore but by the whole experiment.
     /// In my opinion the target should be either the optics, or the magnet end bore.
-    /// Then one should place the optics or the magnet end bore at the (0,0,0).
+    /// Then one should place the optics or the magnet end bore at the (0,0,0) + TargetPosition.
     ///
     do {
         x = 2 * (fRandom->Rndm() - 0.5);
@@ -178,7 +179,7 @@ TRestEvent* TRestAxionGeneratorProcess::ProcessEvent(TRestEvent* evInput) {
 
     r = TMath::Sqrt(r);
 
-    axionPosition = axionPosition + TVector3(fTargetRadius * x, fTargetRadius * y, 0);
+    axionPosition = axionPosition + TVector3(fTargetRadius * x, fTargetRadius * y, 0) + fTargetPosition;
 
     Double_t mass = fRandom->Uniform(fAxionMassRange.X(), fAxionMassRange.Y());
 


### PR DESCRIPTION
![jovoy](https://badgen.net/badge/PR%20submitted%20by%3A/jovoy/blue) ![Ok: 15](https://badgen.net/badge/PR%20Size/Ok%3A%2015/green) [![](https://github.com/rest-for-physics/axionlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=jovoy-target-position)](https://github.com/rest-for-physics/axionlib/commits/jovoy-target-position) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The helioscope might not be pointed towards the sun by one of the bores but by the middle between both bores. The bores are 1600mm apart. To not loose to much statistics by just making a bigger target, the target can, with this PR, be moved up or down, depending on which bore one wants to use.